### PR TITLE
Implement interceptor to append JWT to outbound HTTP requests

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -5,7 +5,8 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { AuthModule } from './auth/auth.module';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { provideHttpClient } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { JwtInterceptor } from './interceptors/jwtInterceptor';
 
 @NgModule({
   declarations: [
@@ -18,7 +19,8 @@ import { provideHttpClient } from '@angular/common/http';
   ],
   providers: [
     provideAnimationsAsync(),
-    provideHttpClient()
+    provideHttpClient(withInterceptorsFromDi()),
+    { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/ui/src/app/interceptors/jwtInterceptor.spec.ts
+++ b/ui/src/app/interceptors/jwtInterceptor.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { HTTP_INTERCEPTORS, HttpClient, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { EXCLUDED_URL_SNIPPETS, JwtInterceptor } from './jwtInterceptor';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+describe('JwtInterceptor', () => {
+    let http: HttpClient;
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                provideHttpClient(withInterceptorsFromDi()),
+                provideHttpClientTesting(),
+                { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true }
+            ]
+        });
+        http = TestBed.inject(HttpClient);
+        httpMock = TestBed.inject(HttpTestingController);
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        httpMock.verify();
+        localStorage.clear();
+    });
+
+    it('should add Authorization header if JWT exists and URL is not excluded', () => {
+        localStorage.setItem('jwt', 'test-token');
+        http.get('/api/data').subscribe();
+        const req = httpMock.expectOne('/api/data');
+        expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+        req.flush({});
+    });
+
+    it('should NOT add Authorization header for any excluded URL snippet', () => {
+        localStorage.setItem('jwt', 'test-token');
+        EXCLUDED_URL_SNIPPETS.forEach(snippet => {
+            http.get(snippet).subscribe();
+            let req = httpMock.expectOne(snippet);
+            expect(req.request.headers.has('Authorization')).toBeFalse();
+            req.flush({});
+
+            http.post(snippet, {}).subscribe();
+            req = httpMock.expectOne(snippet);
+            expect(req.request.headers.has('Authorization')).toBeFalse();
+            req.flush({});
+        });
+    });
+
+    it('should NOT add Authorization header if JWT does not exist', () => {
+        http.get('/api/data').subscribe();
+        const req = httpMock.expectOne('/api/data');
+        expect(req.request.headers.has('Authorization')).toBeFalse();
+        req.flush({});
+    });
+});

--- a/ui/src/app/interceptors/jwtInterceptor.ts
+++ b/ui/src/app/interceptors/jwtInterceptor.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export const EXCLUDED_URL_SNIPPETS = [
+  '/pam/register',
+  '/gateway/login'
+];
+
+@Injectable()
+export class JwtInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const shouldExclude = EXCLUDED_URL_SNIPPETS.some(urlSnip => req.url.includes(urlSnip));
+    if (shouldExclude) {
+      return next.handle(req);
+    }
+
+    const jwt = localStorage.getItem('jwt');
+    if (jwt) {
+      const cloned = req.clone({
+        setHeaders: {
+          Authorization: `Bearer ${jwt}`
+        }
+      });
+      return next.handle(cloned);
+    }
+
+    return next.handle(req);
+  }
+}


### PR DESCRIPTION
- Added JwtInteceptor class to append JWTs to outgoing requests.
- Added testing for JwtInterceptor.
- Included JwtInterceptor in provider array of AppModule.
- Included withInterceptorsFromDI() as an argument to provideHttpClient().